### PR TITLE
fix: suppress biome lint warnings for external API types

### DIFF
--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -1373,6 +1373,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       args.push('--long');
     }
 
+    // biome-ignore lint/style/useExplicitLengthCheck: size is a boolean option, not a length property
     if (opts?.size) {
       args.push('--size');
     }
@@ -1520,6 +1521,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       id: string;
       path: string;
       owner: { name: string };
+      // biome-ignore lint/style/useNamingConvention: locked_at is from git-lfs JSON output
       locked_at: string;
     };
 
@@ -1596,6 +1598,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       id: string;
       path: string;
       owner: { name: string };
+      // biome-ignore lint/style/useNamingConvention: locked_at is from git-lfs JSON output
       locked_at: string;
     }>;
 
@@ -1715,10 +1718,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     });
   }
 
-  private appendMigrateArgs(
-    args: Array<string>,
-    opts?: LfsMigrateInfoOpts,
-  ): void {
+  private appendMigrateArgs(args: Array<string>, opts?: LfsMigrateInfoOpts): void {
     if (opts?.everything) {
       args.push('--everything');
     }
@@ -1831,10 +1831,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
         info.fetchRecentRefsIncludeRemotes =
           line.replace('FetchRecentRefsIncludeRemotes=', '').trim() === 'true';
       } else if (line.startsWith('PruneOffsetDays=')) {
-        info.pruneOffsetDays = Number.parseInt(
-          line.replace('PruneOffsetDays=', '').trim(),
-          10,
-        );
+        info.pruneOffsetDays = Number.parseInt(line.replace('PruneOffsetDays=', '').trim(), 10);
       } else if (line.startsWith('PruneVerifyRemoteAlways=')) {
         info.pruneVerifyRemoteAlways =
           line.replace('PruneVerifyRemoteAlways=', '').trim() === 'true';


### PR DESCRIPTION
## Summary
- Add biome-ignore comments for `locked_at` property from git-lfs JSON output
- Add biome-ignore for `size` boolean check (not a length property)
- Apply biome formatting fixes

These changes fix the 3 lint errors that were causing CI to fail.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm check` passes (74 warnings, 0 errors)
- [x] `pnpm test:ci` passes (180 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)