### PR TITLE
feat: make worktree.add and worktree.move return WorktreeRepo

### DIFF
--- a/src/core/repo.ts
+++ b/src/core/repo.ts
@@ -1910,11 +1910,13 @@ export interface WorktreeOperations {
   list(opts?: ExecOpts): Promise<Array<Worktree>>;
 
   /**
-   * Add a new worktree
+   * Add a new worktree and return a repository object for it
    *
    * Wraps: `git worktree add <path>`
+   *
+   * @returns A WorktreeRepo instance for the newly created worktree
    */
-  add(path: string, opts?: WorktreeAddOpts & ExecOpts): Promise<void>;
+  add(path: string, opts?: WorktreeAddOpts & ExecOpts): Promise<WorktreeRepo>;
 
   /**
    * Remove a worktree

--- a/src/core/repo.ts
+++ b/src/core/repo.ts
@@ -1947,11 +1947,13 @@ export interface WorktreeOperations {
   unlock(path: string, opts?: ExecOpts): Promise<void>;
 
   /**
-   * Move a worktree to a new location
+   * Move a worktree to a new location and return a repository object for it
    *
    * Wraps: `git worktree move <src> <dst>`
+   *
+   * @returns A WorktreeRepo instance for the worktree at the new location
    */
-  move(src: string, dst: string, opts?: WorktreeMoveOpts & ExecOpts): Promise<void>;
+  move(src: string, dst: string, opts?: WorktreeMoveOpts & ExecOpts): Promise<WorktreeRepo>;
 
   /**
    * Repair worktree administrative files

--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -1981,7 +1981,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     src: string,
     dst: string,
     opts?: WorktreeMoveOpts & ExecOpts,
-  ): Promise<void> {
+  ): Promise<WorktreeRepo> {
     const args = ['worktree', 'move'];
 
     if (opts?.force) {
@@ -1993,6 +1993,9 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
     });
+
+    // Return a new WorktreeRepo for the worktree at the new location
+    return new WorktreeRepoImpl(this.runner, dst);
   }
 
   private async worktreeRepair(paths?: Array<string>, opts?: ExecOpts): Promise<void> {

--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -1872,7 +1872,10 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     return parseWorktreeList(result.stdout);
   }
 
-  private async worktreeAdd(path: string, opts?: WorktreeAddOpts & ExecOpts): Promise<void> {
+  private async worktreeAdd(
+    path: string,
+    opts?: WorktreeAddOpts & ExecOpts,
+  ): Promise<WorktreeRepo> {
     const args = ['worktree', 'add'];
 
     if (opts?.detach) {
@@ -1914,6 +1917,9 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
     });
+
+    // Return a new WorktreeRepo for the newly created worktree
+    return new WorktreeRepoImpl(this.runner, path);
   }
 
   private async worktreeRemove(path: string, opts?: WorktreeRemoveOpts & ExecOpts): Promise<void> {

--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -1915,8 +1915,8 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       onProgress: opts?.onProgress,
     });
 
-    // Return a new WorktreeRepo for the newly created worktree
-    return new WorktreeRepoImpl(this.runner, path);
+    // Return a new WorktreeRepo for the newly created worktree, preserving LFS mode
+    return new WorktreeRepoImpl(this.runner, path, { lfs: this._lfsMode });
   }
 
   private async worktreeRemove(path: string, opts?: WorktreeRemoveOpts & ExecOpts): Promise<void> {
@@ -1994,8 +1994,8 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       signal: opts?.signal,
     });
 
-    // Return a new WorktreeRepo for the worktree at the new location
-    return new WorktreeRepoImpl(this.runner, dst);
+    // Return a new WorktreeRepo for the worktree at the new location, preserving LFS mode
+    return new WorktreeRepoImpl(this.runner, dst, { lfs: this._lfsMode });
   }
 
   private async worktreeRepair(paths?: Array<string>, opts?: ExecOpts): Promise<void> {


### PR DESCRIPTION
## Summary
- `worktree.add()` now returns a `WorktreeRepo` instance for the newly created worktree
- `worktree.move()` now returns a `WorktreeRepo` instance for the worktree at its new location
- Enables immediate operations on worktrees without requiring a separate `git.open()` call
- Improves developer experience by providing a fluent API for worktree workflows

## Example Usage

```typescript
// worktree.add - Before: required separate open call
await repo.worktree.add('/path/to/worktree', { branch: 'feature' });
const newWorktree = await git.open('/path/to/worktree');
await newWorktree.checkout('feature');

// worktree.add - After: direct access to the new worktree
const newWorktree = await repo.worktree.add('/path/to/worktree', { branch: 'feature' });
await newWorktree.checkout('feature');

// worktree.move - Now returns WorktreeRepo for new location
const movedWorktree = await repo.worktree.move('/old/path', '/new/path');
const status = await movedWorktree.status();
```

## Test plan
- [x] TypeScript compilation passes (`pnpm typecheck`)
- [x] All existing tests pass (`pnpm test:ci` - 180 tests)
- [ ] Manual verification of worktree.add() returning usable WorktreeRepo
- [ ] Manual verification of worktree.move() returning usable WorktreeRepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)