### PR TITLE
feat: expose config property on TypeGit class

### DIFF
--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -3,7 +3,14 @@
  */
 
 import type { RuntimeAdapters } from '../../core/adapters.js';
-import type { CloneOpts, Git, InitOpts, LsRemoteOpts, LsRemoteResult } from '../../core/git.js';
+import type {
+  CloneOpts,
+  Git,
+  GlobalConfigOperations,
+  InitOpts,
+  LsRemoteOpts,
+  LsRemoteResult,
+} from '../../core/git.js';
 import type { BareRepo, WorktreeRepo } from '../../core/repo.js';
 import type { ExecOpts, GitOpenOptions, RawResult } from '../../core/types.js';
 import { type CreateGitOptions, createGit } from '../../impl/git-impl.js';
@@ -142,5 +149,15 @@ export class TypeGit {
    */
   public get raw(): (argv: Array<string>, opts?: ExecOpts) => Promise<RawResult> {
     return this.git.raw.bind(this.git);
+  }
+
+  /**
+   * Global config operations
+   *
+   * Operates on ~/.gitconfig (user-level configuration).
+   * For repository-level config, use repo.config instead.
+   */
+  public get config(): GlobalConfigOperations {
+    return this.git.config;
   }
 }


### PR DESCRIPTION
## Summary
- Add `config` getter to `TypeGit` class to expose global config operations
- Allows access to `~/.gitconfig` through the convenience API

## Usage
```typescript
import { TypeGit } from 'type-git/node';

const git = new TypeGit();

// Typed API
await git.config.set('user.name', 'Your Name');
const name = await git.config.get('user.name');

// Raw API for arbitrary keys
await git.config.setRaw('custom.key', 'value');
const entries = await git.config.list();
```

## Test plan
- [x] TypeScript type check passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)