### PR TITLE
fix: include root package in pnpm workspace for changesets

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
+  - '.'
   - 'website'


### PR DESCRIPTION
## Summary
- Add root package (`.`) to pnpm-workspace.yaml so changesets can recognize it as a valid workspace package

## Background
The changeset workflow was failing because the root package (type-git) was not included in pnpm-workspace.yaml.

## Test plan
- [ ] Verify changeset workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)