### PR TITLE
fix: use PAT for changesets to trigger CI on Release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           title: 'chore: release package'
           commit: 'chore: release package'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Create Git Tag


### PR DESCRIPTION
## Summary
- Change `GITHUB_TOKEN` to `PAT_TOKEN` for the changesets action

## Background
`GITHUB_TOKEN` doesn't trigger other workflows (to prevent infinite loops). This caused the Release PR (#91) to not trigger CI, blocking the merge.

Using `PAT_TOKEN` allows the Release PR to properly trigger CI checks.

## Prerequisites
⚠️ **Before merging**, add the `PAT_TOKEN` secret:
1. Create a Fine-grained PAT with `Contents` and `Pull requests` permissions for this repo
2. Add it as a repository secret named `PAT_TOKEN`

## Test plan
- [ ] Add `PAT_TOKEN` secret to repository
- [ ] Merge this PR
- [ ] Verify next Release PR triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)