### PR TITLE
feat: prevent implicit parent environment inheritance (env var traversal prevention)

### DIFF
--- a/.changeset/env-var-traversal-prevention.md
+++ b/.changeset/env-var-traversal-prevention.md
@@ -1,0 +1,31 @@
+---
+"type-git": minor
+---
+
+Stop implicitly inheriting the full parent process environment (environment variable traversal prevention)
+
+Previously, every spawned Git command inherited the entire parent process environment. This leaked secrets that happen to live in the parent process (cloud credentials, API tokens, etc.) into Git and any tools it shells out to — credential helpers, hooks, and LFS transfer agents — which is an environment variable traversal risk.
+
+Now, only a curated allowlist of variables that Git genuinely needs to operate (e.g. `PATH`, `HOME`, locale, `SSH_AUTH_SOCK`, proxy settings, and Windows essentials) is inherited by default. Sensitive variables are no longer forwarded.
+
+A new `inheritEnv` option controls this behavior on `createGit()`, `git.open()`/`openBare()`/`openRaw()`, and `CliRunner`:
+
+- `undefined` (default): inherit only the built-in safe allowlist (`DEFAULT_ENV_ALLOWLIST`).
+- `true`: inherit the entire parent environment (previous behavior, opt-in).
+- `false`: inherit nothing beyond explicitly provided `env`.
+- `string[]`: inherit the default allowlist plus the named variables.
+
+```typescript
+// Opt a specific variable back in
+const git = await createGit({
+  adapters: createNodeAdapters(),
+  inheritEnv: ['MY_CUSTOM_VAR'],
+});
+
+// Restore the previous "inherit everything" behavior
+const repo = await git.open('/path/to/repo', { inheritEnv: true });
+```
+
+**Breaking:** Workflows that relied on arbitrary parent environment variables reaching Git (for example a commit-signing or credential helper that reads a token from the environment) must now opt those variables back in via `inheritEnv`.
+
+New exports: `EnvInheritance`, `DEFAULT_ENV_ALLOWLIST`, `resolveInheritedEnv`.

--- a/src/adapters/bun/exec.ts
+++ b/src/adapters/bun/exec.ts
@@ -14,6 +14,23 @@ import type {
 import type { Capabilities } from '../../core/types.js';
 
 /**
+ * Resolve the environment passed to the child process.
+ *
+ * When `inheritEnv` is `false`, only the explicitly provided `env` is used so the parent
+ * process environment is not implicitly forwarded (environment variable traversal
+ * prevention). Otherwise the parent environment is merged underneath `env`.
+ */
+function resolveChildEnv(
+  env: Record<string, string> | undefined,
+  inheritEnv: boolean | undefined,
+): Record<string, string | undefined> {
+  if (inheritEnv === false) {
+    return env ?? {};
+  }
+  return env ? { ...Bun.env, ...env } : Bun.env;
+}
+
+/**
  * Create an async iterable from a ReadableStream
  */
 async function* streamToAsyncIterable(
@@ -85,7 +102,7 @@ export class BunExecAdapter implements ExecAdapter {
   }
 
   public async spawn(options: SpawnOptions, handlers?: StreamHandler): Promise<SpawnResult> {
-    const { argv, env, cwd, signal } = options;
+    const { argv, env, inheritEnv, cwd, signal } = options;
 
     const command = argv[0];
     if (command === undefined) {
@@ -107,7 +124,7 @@ export class BunExecAdapter implements ExecAdapter {
 
     const proc = Bun.spawn([command, ...args], {
       cwd,
-      env: env ? { ...Bun.env, ...env } : Bun.env,
+      env: resolveChildEnv(env, inheritEnv),
       stdout: 'pipe',
       stderr: 'pipe',
       stdin: 'ignore',
@@ -202,7 +219,7 @@ export class BunExecAdapter implements ExecAdapter {
   }
 
   public spawnStreaming(options: SpawnOptions): SpawnHandle {
-    const { argv, env, cwd, signal } = options;
+    const { argv, env, inheritEnv, cwd, signal } = options;
 
     const command = argv[0];
     if (command === undefined) {
@@ -213,7 +230,7 @@ export class BunExecAdapter implements ExecAdapter {
 
     const proc = Bun.spawn([command, ...args], {
       cwd,
-      env: env ? { ...Bun.env, ...env } : Bun.env,
+      env: resolveChildEnv(env, inheritEnv),
       stdout: 'pipe',
       stderr: 'pipe',
       stdin: 'ignore',

--- a/src/adapters/deno/exec.ts
+++ b/src/adapters/deno/exec.ts
@@ -22,6 +22,7 @@ declare const Deno: {
       args?: string[];
       cwd?: string;
       env?: Record<string, string>;
+      clearEnv?: boolean;
       stdin?: 'piped' | 'inherit' | 'null';
       stdout?: 'piped' | 'inherit' | 'null';
       stderr?: 'piped' | 'inherit' | 'null';
@@ -50,6 +51,24 @@ declare const Deno: {
     toObject(): Record<string, string>;
   };
 };
+
+/**
+ * Resolve the environment options passed to `Deno.Command`.
+ *
+ * Deno merges the provided `env` on top of the parent environment unless `clearEnv` is
+ * set. When `inheritEnv` is `false`, `clearEnv: true` is used so only the explicitly
+ * provided `env` reaches the child (environment variable traversal prevention).
+ * Otherwise the parent environment is merged underneath `env`.
+ */
+function resolveChildEnvOptions(
+  env: Record<string, string> | undefined,
+  inheritEnv: boolean | undefined,
+): { env?: Record<string, string>; clearEnv?: boolean } {
+  if (inheritEnv === false) {
+    return { env: env ?? {}, clearEnv: true };
+  }
+  return { env: env ? { ...Deno.env.toObject(), ...env } : undefined };
+}
 
 /**
  * Create an async iterable from a ReadableStream
@@ -123,7 +142,7 @@ export class DenoExecAdapter implements ExecAdapter {
   }
 
   public async spawn(options: SpawnOptions, handlers?: StreamHandler): Promise<SpawnResult> {
-    const { argv, env, cwd, signal } = options;
+    const { argv, env, inheritEnv, cwd, signal } = options;
 
     const command = argv[0];
     if (command === undefined) {
@@ -146,7 +165,7 @@ export class DenoExecAdapter implements ExecAdapter {
     const cmd = new Deno.Command(command, {
       args,
       cwd,
-      env: env ? { ...Deno.env.toObject(), ...env } : undefined,
+      ...resolveChildEnvOptions(env, inheritEnv),
       stdin: 'null',
       stdout: 'piped',
       stderr: 'piped',
@@ -246,7 +265,7 @@ export class DenoExecAdapter implements ExecAdapter {
   }
 
   public spawnStreaming(options: SpawnOptions): SpawnHandle {
-    const { argv, env, cwd, signal } = options;
+    const { argv, env, inheritEnv, cwd, signal } = options;
 
     const command = argv[0];
     if (command === undefined) {
@@ -258,7 +277,7 @@ export class DenoExecAdapter implements ExecAdapter {
     const cmd = new Deno.Command(command, {
       args,
       cwd,
-      env: env ? { ...Deno.env.toObject(), ...env } : undefined,
+      ...resolveChildEnvOptions(env, inheritEnv),
       stdin: 'null',
       stdout: 'piped',
       stderr: 'piped',

--- a/src/adapters/node/exec.test.ts
+++ b/src/adapters/node/exec.test.ts
@@ -99,9 +99,12 @@ describe('NodeExecAdapter', () => {
       vi.stubEnv('TYPE_GIT_PARENT_ONLY', 'leaked');
       try {
         // Provide PATH explicitly so node can still be located, but nothing else.
+        // Resolve the PATH key case-insensitively (Windows uses `Path`) so the value is
+        // not empty there, which would prevent `node` from being found.
+        const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path');
         const result = await adapter.spawn({
           argv: ['node', '-e', 'console.log(process.env.TYPE_GIT_PARENT_ONLY ?? "undefined")'],
-          env: { PATH: process.env.PATH ?? '' },
+          env: { [pathKey ?? 'PATH']: (pathKey && process.env[pathKey]) || '' },
           inheritEnv: false,
         });
 

--- a/src/adapters/node/exec.test.ts
+++ b/src/adapters/node/exec.test.ts
@@ -5,7 +5,7 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { NodeExecAdapter } from './exec.js';
 
 // Normalize path separators for cross-platform comparison
@@ -93,6 +93,36 @@ describe('NodeExecAdapter', () => {
       });
 
       expect(result.stdout.trim()).toBe('test-value');
+    });
+
+    it('should not inherit the parent environment when inheritEnv is false', async () => {
+      vi.stubEnv('TYPE_GIT_PARENT_ONLY', 'leaked');
+      try {
+        // Provide PATH explicitly so node can still be located, but nothing else.
+        const result = await adapter.spawn({
+          argv: ['node', '-e', 'console.log(process.env.TYPE_GIT_PARENT_ONLY ?? "undefined")'],
+          env: { PATH: process.env.PATH ?? '' },
+          inheritEnv: false,
+        });
+
+        expect(result.stdout.trim()).toBe('undefined');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should inherit the parent environment by default', async () => {
+      vi.stubEnv('TYPE_GIT_PARENT_ONLY', 'inherited');
+      try {
+        const result = await adapter.spawn({
+          argv: ['node', '-e', 'console.log(process.env.TYPE_GIT_PARENT_ONLY ?? "undefined")'],
+          env: { OTHER: 'x' },
+        });
+
+        expect(result.stdout.trim()).toBe('inherited');
+      } finally {
+        vi.unstubAllEnvs();
+      }
     });
 
     it('should support AbortSignal', async () => {

--- a/src/adapters/node/exec.ts
+++ b/src/adapters/node/exec.ts
@@ -13,6 +13,23 @@ import type {
 import type { Capabilities } from '../../core/types.js';
 
 /**
+ * Resolve the environment passed to the child process.
+ *
+ * When `inheritEnv` is `false`, only the explicitly provided `env` is used so the parent
+ * process environment is not implicitly forwarded (environment variable traversal
+ * prevention). Otherwise the parent environment is merged underneath `env`.
+ */
+function resolveChildEnv(
+  env: Record<string, string> | undefined,
+  inheritEnv: boolean | undefined,
+): NodeJS.ProcessEnv {
+  if (inheritEnv === false) {
+    return env ?? {};
+  }
+  return env ? { ...process.env, ...env } : process.env;
+}
+
+/**
  * Create an async iterable from a readable stream
  */
 async function* streamToAsyncIterable(
@@ -49,7 +66,7 @@ export class NodeExecAdapter implements ExecAdapter {
   }
 
   public spawn(options: SpawnOptions, handlers?: StreamHandler): Promise<SpawnResult> {
-    const { argv, env, cwd, signal } = options;
+    const { argv, env, inheritEnv, cwd, signal } = options;
 
     const command = argv[0];
     if (command === undefined) {
@@ -60,7 +77,7 @@ export class NodeExecAdapter implements ExecAdapter {
     return new Promise((resolve, reject) => {
       const child = spawn(command, args, {
         cwd,
-        env: env ? { ...process.env, ...env } : process.env,
+        env: resolveChildEnv(env, inheritEnv),
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 
@@ -116,7 +133,7 @@ export class NodeExecAdapter implements ExecAdapter {
   }
 
   public spawnStreaming(options: SpawnOptions): SpawnHandle {
-    const { argv, env, cwd, signal } = options;
+    const { argv, env, inheritEnv, cwd, signal } = options;
 
     const command = argv[0];
     if (command === undefined) {
@@ -126,7 +143,7 @@ export class NodeExecAdapter implements ExecAdapter {
 
     const child = spawn(command, args, {
       cwd,
-      env: env ? { ...process.env, ...env } : process.env,
+      env: resolveChildEnv(env, inheritEnv),
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/src/core/adapters.ts
+++ b/src/core/adapters.ts
@@ -21,6 +21,16 @@ export type SpawnOptions = {
   argv: string[];
   /** Additional environment variables */
   env?: Record<string, string>;
+  /**
+   * Whether to merge the parent process environment underneath `env`.
+   *
+   * - `true` (default when omitted): the parent environment is merged underneath `env`,
+   *   so the child inherits the full parent environment with `env` overrides on top.
+   * - `false`: the child receives only the variables in `env` (and nothing from the
+   *   parent process). This prevents implicit environment variable traversal — used by
+   *   {@link CliRunner}, which resolves the inherited variables itself.
+   */
+  inheritEnv?: boolean;
   /** Working directory */
   cwd?: string;
   /** AbortSignal for cancellation */

--- a/src/core/env.test.ts
+++ b/src/core/env.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for environment variable inheritance control (traversal prevention)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_ENV_ALLOWLIST, resolveInheritedEnv } from './env.js';
+
+describe('resolveInheritedEnv', () => {
+  const parentEnv = {
+    PATH: '/usr/bin:/bin',
+    HOME: '/home/user',
+    SSH_AUTH_SOCK: '/tmp/ssh-agent.sock',
+    AWS_SECRET_ACCESS_KEY: 'super-secret',
+    MY_API_TOKEN: 'token-value',
+    UNDEFINED_VAR: undefined,
+  };
+
+  describe('default behavior (allowlist)', () => {
+    it('inherits allowlisted variables', () => {
+      const result = resolveInheritedEnv(parentEnv);
+
+      expect(result.PATH).toBe('/usr/bin:/bin');
+      expect(result.HOME).toBe('/home/user');
+      expect(result.SSH_AUTH_SOCK).toBe('/tmp/ssh-agent.sock');
+    });
+
+    it('does NOT inherit sensitive variables outside the allowlist', () => {
+      const result = resolveInheritedEnv(parentEnv);
+
+      expect(result.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      expect(result.MY_API_TOKEN).toBeUndefined();
+    });
+
+    it('drops variables with undefined values', () => {
+      const result = resolveInheritedEnv(parentEnv);
+
+      expect('UNDEFINED_VAR' in result).toBe(false);
+    });
+  });
+
+  describe('inheritEnv: true', () => {
+    it('inherits the entire parent environment', () => {
+      const result = resolveInheritedEnv(parentEnv, true);
+
+      expect(result.PATH).toBe('/usr/bin:/bin');
+      expect(result.AWS_SECRET_ACCESS_KEY).toBe('super-secret');
+      expect(result.MY_API_TOKEN).toBe('token-value');
+    });
+
+    it('still drops undefined values', () => {
+      const result = resolveInheritedEnv(parentEnv, true);
+
+      expect('UNDEFINED_VAR' in result).toBe(false);
+    });
+  });
+
+  describe('inheritEnv: false', () => {
+    it('inherits nothing', () => {
+      const result = resolveInheritedEnv(parentEnv, false);
+
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+  });
+
+  describe('inheritEnv: string[]', () => {
+    it('extends the default allowlist with named variables', () => {
+      const result = resolveInheritedEnv(parentEnv, ['MY_API_TOKEN']);
+
+      // Still inherits defaults
+      expect(result.PATH).toBe('/usr/bin:/bin');
+      // Plus the explicitly opted-in variable
+      expect(result.MY_API_TOKEN).toBe('token-value');
+      // But not other secrets
+      expect(result.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+    });
+  });
+
+  describe('Windows case-insensitive matching', () => {
+    it('matches allowlist entries regardless of case on win32', () => {
+      const winEnv = {
+        Path: 'C:\\Windows',
+        SystemRoot: 'C:\\Windows',
+        SECRET: 'nope',
+      };
+
+      const result = resolveInheritedEnv(winEnv, undefined, 'win32');
+
+      expect(result.Path).toBe('C:\\Windows');
+      expect(result.SystemRoot).toBe('C:\\Windows');
+      expect(result.SECRET).toBeUndefined();
+    });
+
+    it('is case-sensitive on non-Windows platforms', () => {
+      const env = { path: '/usr/bin' };
+
+      const result = resolveInheritedEnv(env, undefined, 'linux');
+
+      // Lowercase 'path' should NOT match allowlist entry 'PATH' on linux
+      expect(result.path).toBeUndefined();
+    });
+  });
+
+  describe('DEFAULT_ENV_ALLOWLIST', () => {
+    it('includes PATH and HOME', () => {
+      expect(DEFAULT_ENV_ALLOWLIST).toContain('PATH');
+      expect(DEFAULT_ENV_ALLOWLIST).toContain('HOME');
+    });
+  });
+});

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,0 +1,146 @@
+/**
+ * Environment variable inheritance control (environment variable traversal prevention)
+ *
+ * By default, type-git does NOT pass the entire parent process environment to the
+ * spawned Git subprocess. Leaking the full environment into Git (and from there into
+ * credential helpers, hooks, and LFS transfer agents) is an environment variable
+ * traversal risk: secrets such as cloud credentials or API tokens that live in the
+ * parent process can be exfiltrated by untrusted Git configuration or remote-controlled
+ * helpers.
+ *
+ * Instead, only a curated allowlist of variables that Git genuinely needs to operate is
+ * inherited. Callers can widen or replace this behavior via the `inheritEnv` option.
+ */
+
+/**
+ * Controls how the parent process environment is inherited by spawned Git commands.
+ *
+ * - `undefined` (default): inherit only {@link DEFAULT_ENV_ALLOWLIST} — the variables
+ *   Git needs to function. Sensitive variables are not passed through.
+ * - `true`: inherit the entire parent environment (legacy behavior, opt-in).
+ * - `false`: inherit nothing. The child only receives explicitly provided variables and
+ *   values computed by the library (e.g. `HOME`, `PATH` prefixes). Note that this may
+ *   break Git if `PATH` is not otherwise supplied.
+ * - `string[]`: inherit {@link DEFAULT_ENV_ALLOWLIST} plus the named variables. Use this
+ *   to explicitly opt specific variables (e.g. an SSH command or a token) back in.
+ */
+export type EnvInheritance = boolean | string[];
+
+/**
+ * Curated allowlist of environment variables inherited by default.
+ *
+ * These are variables Git (and the tools it shells out to, such as ssh and credential
+ * helpers) commonly needs to operate. The list intentionally excludes arbitrary
+ * application secrets so they are not silently forwarded to Git subprocesses.
+ *
+ * Variable names are matched case-insensitively on Windows.
+ */
+export const DEFAULT_ENV_ALLOWLIST: readonly string[] = [
+  // Executable resolution
+  'PATH',
+  'PATHEXT',
+  // User home / identity
+  'HOME',
+  'USER',
+  'LOGNAME',
+  // Locale and time
+  'LANG',
+  'LANGUAGE',
+  'LC_ALL',
+  'LC_CTYPE',
+  'LC_MESSAGES',
+  'LC_NUMERIC',
+  'LC_TIME',
+  'LC_COLLATE',
+  'LC_MONETARY',
+  'TZ',
+  // Temporary directories
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  // Terminal
+  'TERM',
+  'COLORTERM',
+  // SSH agent (required for Git-over-SSH authentication)
+  'SSH_AUTH_SOCK',
+  'SSH_AGENT_PID',
+  // HTTP(S) proxy configuration (required for Git network operations behind a proxy)
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy',
+  // Windows essentials
+  'USERPROFILE',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'PROGRAMDATA',
+  'ALLUSERSPROFILE',
+  'PROGRAMFILES',
+  'PROGRAMFILES(X86)',
+  'PROGRAMW6432',
+  'PUBLIC',
+  'SYSTEMROOT',
+  'SYSTEMDRIVE',
+  'WINDIR',
+  'COMSPEC',
+  'COMPUTERNAME',
+  'USERDOMAIN',
+  'NUMBER_OF_PROCESSORS',
+  'PROCESSOR_ARCHITECTURE',
+];
+
+/**
+ * Resolve the set of environment variables to inherit from the parent process.
+ *
+ * @param parentEnv - The parent process environment (e.g. `process.env`).
+ * @param inheritEnv - Inheritance policy. See {@link EnvInheritance}.
+ * @param platform - The runtime platform (e.g. `process.platform`). When `'win32'`,
+ *   variable names are matched case-insensitively.
+ * @returns A record containing only the inherited variables (undefined values removed).
+ */
+export function resolveInheritedEnv(
+  parentEnv: Record<string, string | undefined>,
+  inheritEnv?: EnvInheritance,
+  platform: string = '',
+): Record<string, string> {
+  // Legacy behavior: inherit the entire parent environment.
+  if (inheritEnv === true) {
+    const all: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parentEnv)) {
+      if (value !== undefined) {
+        all[key] = value;
+      }
+    }
+    return all;
+  }
+
+  // Build the allowlist. `false` means inherit nothing; an array extends the defaults.
+  const allow = new Set<string>(inheritEnv === false ? [] : DEFAULT_ENV_ALLOWLIST);
+  if (Array.isArray(inheritEnv)) {
+    for (const name of inheritEnv) {
+      allow.add(name);
+    }
+  }
+
+  // Windows environment variable names are case-insensitive.
+  const isWindows = platform === 'win32';
+  const allowLower = isWindows ? new Set([...allow].map((name) => name.toLowerCase())) : null;
+
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parentEnv)) {
+    if (value === undefined) {
+      continue;
+    }
+    const allowed = allowLower ? allowLower.has(key.toLowerCase()) : allow.has(key);
+    if (allowed) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './adapters.js';
+export * from './env.js';
 export * from './git.js';
 export * from './repo.js';
 export * from './types.js';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -10,6 +10,8 @@
  * - Branded types for type safety
  */
 
+import type { EnvInheritance } from './env.js';
+
 // =============================================================================
 // Branded Types for Type Safety
 // =============================================================================
@@ -382,6 +384,15 @@ export type GitOpenOptions = {
   credentialHelper?: string;
   /** Additional environment variables */
   env?: Record<string, string>;
+  /**
+   * Controls how the parent process environment is inherited by spawned Git commands.
+   *
+   * By default, only a curated allowlist of variables that Git needs to operate is
+   * inherited (environment variable traversal prevention). Set to `true` to inherit the
+   * full parent environment, or provide an array of variable names to opt additional
+   * variables back in.
+   */
+  inheritEnv?: EnvInheritance;
   /** Directories to prepend to PATH */
   pathPrefix?: string[];
   /** Credential configuration (§6.4) */

--- a/src/impl/git-impl.ts
+++ b/src/impl/git-impl.ts
@@ -222,6 +222,7 @@ function toCliRunnerOptions(opts?: GitOpenOptions): CliRunnerOptions {
 
   return {
     env: opts.env,
+    inheritEnv: opts.inheritEnv,
     pathPrefix: opts.pathPrefix,
     home: opts.home,
     credential: opts.credential

--- a/src/runner/cli-runner.test.ts
+++ b/src/runner/cli-runner.test.ts
@@ -318,15 +318,16 @@ describe('CliRunner', () => {
       expect(spawnCall[0].env.SHARED_VAR).toBe('derived');
     });
 
-    it('should reuse an existing case-variant PATH key when applying the prefix', async () => {
-      // On Windows the inherited variable is commonly named `Path`. The prefix logic must
-      // reuse that key instead of creating a separate uppercase `PATH`, which would orphan
-      // the inherited value.
+    it('should apply the PATH prefix to the platform PATH key without orphaning it', async () => {
+      // On Windows the PATH variable is commonly named `Path` and matched
+      // case-insensitively, so the prefix logic must reuse that key. On other platforms
+      // names are case-sensitive and the canonical `PATH` is always used.
+      const pathKey = process.platform === 'win32' ? 'Path' : 'PATH';
       const adapters = createMockAdapters();
       const runner = new CliRunner(adapters, {
-        // Disable allowlist inheritance so the only PATH-like key is the case variant below
+        // Disable allowlist inheritance so the only PATH key is the one provided below
         inheritEnv: false,
-        env: { Path: '/inherited/bin' },
+        env: { [pathKey]: '/inherited/bin' },
         pathPrefix: ['/custom/bin'],
       });
 
@@ -334,11 +335,9 @@ describe('CliRunner', () => {
 
       const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
       const envArg = spawnCall[0].env;
-      // The original key is reused and retains the inherited value
-      expect(envArg.Path).toContain('/custom/bin');
-      expect(envArg.Path).toContain('/inherited/bin');
-      // No duplicate uppercase PATH containing only the prefix
-      expect(envArg.PATH).toBeUndefined();
+      // The prefix is applied to the platform PATH key and the inherited value is retained
+      expect(envArg[pathKey]).toContain('/custom/bin');
+      expect(envArg[pathKey]).toContain('/inherited/bin');
     });
 
     it('should instruct the adapter not to inherit the parent environment', async () => {

--- a/src/runner/cli-runner.test.ts
+++ b/src/runner/cli-runner.test.ts
@@ -45,6 +45,10 @@ function createMockAdapters(spawnResult?: Partial<SpawnResult>): RuntimeAdapters
   };
 }
 
+// The PATH variable key as it appears in this platform's process.env.
+// Windows commonly stores it as `Path` (case-insensitive), other platforms use `PATH`.
+const PATH_KEY = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+
 describe('CliRunner', () => {
   describe('run', () => {
     it('should execute command with global context', async () => {
@@ -265,16 +269,16 @@ describe('CliRunner', () => {
 
     it('should apply PATH prefix', async () => {
       const adapters = createMockAdapters();
-      const originalPath = process.env.PATH;
+      const originalPath = process.env[PATH_KEY];
       const runner = new CliRunner(adapters, { pathPrefix: ['/custom/bin', '/another/bin'] });
 
       await runner.run({ type: 'global' }, ['version']);
 
       const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
       const envArg = spawnCall[0].env;
-      expect(envArg.PATH).toContain('/custom/bin');
-      expect(envArg.PATH).toContain('/another/bin');
-      expect(envArg.PATH).toContain(originalPath);
+      expect(envArg[PATH_KEY]).toContain('/custom/bin');
+      expect(envArg[PATH_KEY]).toContain('/another/bin');
+      expect(envArg[PATH_KEY]).toContain(originalPath);
     });
 
     it('should merge options with withOptions()', async () => {
@@ -361,7 +365,7 @@ describe('CliRunner', () => {
         const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
         expect(spawnCall[0].env.TYPE_GIT_TEST_SECRET).toBeUndefined();
         // But allowlisted vars such as PATH are still inherited
-        expect(spawnCall[0].env.PATH).toBeDefined();
+        expect(spawnCall[0].env[PATH_KEY]).toBeDefined();
       } finally {
         vi.unstubAllEnvs();
       }

--- a/src/runner/cli-runner.test.ts
+++ b/src/runner/cli-runner.test.ts
@@ -317,6 +317,81 @@ describe('CliRunner', () => {
       const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(spawnCall[0].env.SHARED_VAR).toBe('derived');
     });
+
+    it('should instruct the adapter not to inherit the parent environment', async () => {
+      const adapters = createMockAdapters();
+      const runner = new CliRunner(adapters);
+
+      await runner.run({ type: 'global' }, ['version']);
+
+      const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(spawnCall[0].inheritEnv).toBe(false);
+    });
+
+    it('should not forward sensitive parent env vars by default', async () => {
+      const adapters = createMockAdapters();
+      vi.stubEnv('TYPE_GIT_TEST_SECRET', 'super-secret');
+      try {
+        const runner = new CliRunner(adapters);
+
+        await runner.run({ type: 'global' }, ['version']);
+
+        const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(spawnCall[0].env.TYPE_GIT_TEST_SECRET).toBeUndefined();
+        // But allowlisted vars such as PATH are still inherited
+        expect(spawnCall[0].env.PATH).toBeDefined();
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should forward all parent env vars when inheritEnv is true', async () => {
+      const adapters = createMockAdapters();
+      vi.stubEnv('TYPE_GIT_TEST_SECRET', 'super-secret');
+      try {
+        const runner = new CliRunner(adapters, { inheritEnv: true });
+
+        await runner.run({ type: 'global' }, ['version']);
+
+        const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(spawnCall[0].env.TYPE_GIT_TEST_SECRET).toBe('super-secret');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should opt specific parent env vars back in via inheritEnv array', async () => {
+      const adapters = createMockAdapters();
+      vi.stubEnv('TYPE_GIT_TEST_OPT_IN', 'opt-in-value');
+      vi.stubEnv('TYPE_GIT_TEST_SECRET', 'super-secret');
+      try {
+        const runner = new CliRunner(adapters, { inheritEnv: ['TYPE_GIT_TEST_OPT_IN'] });
+
+        await runner.run({ type: 'global' }, ['version']);
+
+        const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(spawnCall[0].env.TYPE_GIT_TEST_OPT_IN).toBe('opt-in-value');
+        expect(spawnCall[0].env.TYPE_GIT_TEST_SECRET).toBeUndefined();
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should propagate inheritEnv through withOptions()', async () => {
+      const adapters = createMockAdapters();
+      vi.stubEnv('TYPE_GIT_TEST_SECRET', 'super-secret');
+      try {
+        const baseRunner = new CliRunner(adapters, { inheritEnv: true });
+        const derivedRunner = baseRunner.withOptions({ env: { EXTRA: 'x' } });
+
+        await derivedRunner.run({ type: 'global' }, ['version']);
+
+        const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(spawnCall[0].env.TYPE_GIT_TEST_SECRET).toBe('super-secret');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
   });
 
   describe('credential helper', () => {

--- a/src/runner/cli-runner.test.ts
+++ b/src/runner/cli-runner.test.ts
@@ -318,6 +318,29 @@ describe('CliRunner', () => {
       expect(spawnCall[0].env.SHARED_VAR).toBe('derived');
     });
 
+    it('should reuse an existing case-variant PATH key when applying the prefix', async () => {
+      // On Windows the inherited variable is commonly named `Path`. The prefix logic must
+      // reuse that key instead of creating a separate uppercase `PATH`, which would orphan
+      // the inherited value.
+      const adapters = createMockAdapters();
+      const runner = new CliRunner(adapters, {
+        // Disable allowlist inheritance so the only PATH-like key is the case variant below
+        inheritEnv: false,
+        env: { Path: '/inherited/bin' },
+        pathPrefix: ['/custom/bin'],
+      });
+
+      await runner.run({ type: 'global' }, ['version']);
+
+      const spawnCall = (adapters.exec.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+      const envArg = spawnCall[0].env;
+      // The original key is reused and retains the inherited value
+      expect(envArg.Path).toContain('/custom/bin');
+      expect(envArg.Path).toContain('/inherited/bin');
+      // No duplicate uppercase PATH containing only the prefix
+      expect(envArg.PATH).toBeUndefined();
+    });
+
     it('should instruct the adapter not to inherit the parent environment', async () => {
       const adapters = createMockAdapters();
       const runner = new CliRunner(adapters);

--- a/src/runner/cli-runner.ts
+++ b/src/runner/cli-runner.ts
@@ -274,9 +274,13 @@ export class CliRunner {
     // Apply PATH prefix
     if (allPathPrefixes.length > 0) {
       const separator = process.platform === 'win32' ? ';' : ':';
+      // Locate the existing PATH variable case-insensitively. Windows commonly uses
+      // `Path`, so writing to `PATH` would orphan the inherited value and break command
+      // resolution. Reuse the existing key (or default to `PATH`) to avoid duplicates.
+      const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
       // Prepend to the already-resolved PATH (which respects the inheritEnv allowlist)
-      const currentPath = env.PATH ?? '';
-      env.PATH = [...allPathPrefixes, currentPath].join(separator);
+      const currentPath = env[pathKey] ?? '';
+      env[pathKey] = [...allPathPrefixes, currentPath].join(separator);
     }
 
     // Enable GIT_TRACE when trace callback is provided (only if not already set)

--- a/src/runner/cli-runner.ts
+++ b/src/runner/cli-runner.ts
@@ -9,6 +9,7 @@
 
 import process from 'node:process';
 import type { ExecAdapter, RuntimeAdapters } from '../core/adapters.js';
+import { type EnvInheritance, resolveInheritedEnv } from '../core/env.js';
 import type {
   AuditConfig,
   ExecOpts,
@@ -125,6 +126,16 @@ export type CliRunnerOptions = {
   gitBinary?: string;
   /** Additional environment variables */
   env?: Record<string, string>;
+  /**
+   * Controls how the parent process environment is inherited by spawned Git commands.
+   *
+   * By default, only a curated allowlist of variables that Git needs to operate is
+   * inherited (environment variable traversal prevention); the full parent environment is
+   * NOT forwarded. See {@link EnvInheritance} for all options.
+   *
+   * @default undefined (inherit the default allowlist)
+   */
+  inheritEnv?: EnvInheritance;
   /** Directories to prepend to PATH */
   pathPrefix?: string[];
   /** Custom HOME directory for git config isolation */
@@ -148,6 +159,7 @@ export class CliRunner {
   private readonly exec: ExecAdapter;
   private readonly gitBinary: string;
   private readonly baseEnv: Record<string, string>;
+  private readonly inheritEnv: EnvInheritance | undefined;
   private readonly pathPrefix: string[];
   private readonly home: string | undefined;
   private readonly credential: CredentialHelperConfig | undefined;
@@ -157,6 +169,7 @@ export class CliRunner {
     this.exec = adapters.exec;
     this.gitBinary = options?.gitBinary ?? 'git';
     this.baseEnv = options?.env ?? {};
+    this.inheritEnv = options?.inheritEnv;
     this.pathPrefix = options?.pathPrefix ?? [];
     this.home = options?.home;
     this.credential = options?.credential;
@@ -171,6 +184,7 @@ export class CliRunner {
   public withOptions(options: CliRunnerOptions): CliRunner {
     const mergedEnv = { ...this.baseEnv, ...options.env };
     const mergedPathPrefix = [...this.pathPrefix, ...(options.pathPrefix ?? [])];
+    const inheritEnv = options.inheritEnv ?? this.inheritEnv;
     const home = options.home ?? this.home;
     const credential = options.credential ?? this.credential;
     const audit = options.audit ?? this.audit;
@@ -189,6 +203,7 @@ export class CliRunner {
       {
         gitBinary: options.gitBinary ?? this.gitBinary,
         env: mergedEnv,
+        inheritEnv,
         pathPrefix: mergedPathPrefix,
         home,
         credential,
@@ -227,10 +242,16 @@ export class CliRunner {
   /**
    * Build the effective environment for command execution
    *
-   * Applies home directory and PATH prefix overrides
+   * Seeds the environment from the inherited (allowlisted) parent variables, then layers
+   * the configured `env`, home directory, and PATH prefix overrides on top. The parent
+   * process environment is never forwarded wholesale unless `inheritEnv: true` is set
+   * (environment variable traversal prevention).
    */
   private buildEnv(): Record<string, string> {
-    const env: Record<string, string> = { ...this.baseEnv };
+    const env: Record<string, string> = {
+      ...resolveInheritedEnv(process.env, this.inheritEnv, process.platform),
+      ...this.baseEnv,
+    };
 
     // Apply home directory override
     if (this.home) {
@@ -253,7 +274,8 @@ export class CliRunner {
     // Apply PATH prefix
     if (allPathPrefixes.length > 0) {
       const separator = process.platform === 'win32' ? ';' : ':';
-      const currentPath = process.env.PATH ?? '';
+      // Prepend to the already-resolved PATH (which respects the inheritEnv allowlist)
+      const currentPath = env.PATH ?? '';
       env.PATH = [...allPathPrefixes, currentPath].join(separator);
     }
 
@@ -324,6 +346,9 @@ export class CliRunner {
         {
           argv,
           env,
+          // The env above is already fully resolved (including any inherited variables),
+          // so the adapter must not merge the parent environment on top of it.
+          inheritEnv: false,
           cwd: context.type === 'worktree' ? context.workdir : undefined,
           signal,
         },

--- a/src/runner/cli-runner.ts
+++ b/src/runner/cli-runner.ts
@@ -273,11 +273,15 @@ export class CliRunner {
 
     // Apply PATH prefix
     if (allPathPrefixes.length > 0) {
-      const separator = process.platform === 'win32' ? ';' : ':';
-      // Locate the existing PATH variable case-insensitively. Windows commonly uses
-      // `Path`, so writing to `PATH` would orphan the inherited value and break command
-      // resolution. Reuse the existing key (or default to `PATH`) to avoid duplicates.
-      const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+      const isWindows = process.platform === 'win32';
+      const separator = isWindows ? ';' : ':';
+      // On Windows, env var names are case-insensitive and PATH is commonly stored as
+      // `Path`; reuse whatever case variant exists so the prefix is applied to the
+      // inherited value instead of orphaning it under a duplicate `PATH` key. On other
+      // platforms names are case-sensitive, so always use the canonical `PATH`.
+      const pathKey = isWindows
+        ? (Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH')
+        : 'PATH';
       // Prepend to the already-resolved PATH (which respects the inheritEnv allowlist)
       const currentPath = env[pathKey] ?? '';
       env[pathKey] = [...allPathPrefixes, currentPath].join(separator);


### PR DESCRIPTION
## Summary

Stops Git subprocesses from **implicitly inheriting the full parent process environment**, as an environment variable traversal prevention measure.

Previously, every spawned Git command inherited the **entire** parent process environment. As a result, secrets living in the parent process (cloud credentials, API tokens, etc.) flowed into Git and into the tools Git shells out to (credential helpers, hooks, LFS transfer agents) — an environment variable traversal risk.

This PR changes the default so that **only a curated allowlist of variables Git needs to operate** is inherited. Sensitive variables are no longer forwarded.

## Changes

- **`src/core/env.ts` (new)**
  - `EnvInheritance` type (`boolean | string[]`)
  - `DEFAULT_ENV_ALLOWLIST` (`PATH`, `HOME`, locale, `SSH_AUTH_SOCK`, proxy settings, Windows essentials, etc.)
  - `resolveInheritedEnv()` (case-insensitive matching on Windows)
- **`CliRunner`**: resolves the inherited variables via the allowlist and instructs the adapter not to merge the parent environment (new `SpawnOptions.inheritEnv`). PATH-prefix logic reuses the platform PATH key (case-insensitive only on Windows).
- **Node / Bun / Deno adapters**: honor `inheritEnv` (Deno uses `clearEnv: true`).
- **`inheritEnv` option** added to `createGit()`, `git.open()` / `openBare()` / `openRaw()`, and `CliRunner`.

## `inheritEnv` behavior

| Value | Behavior |
| --- | --- |
| `undefined` (default) | Inherit only the built-in safe allowlist |
| `true` | Inherit the entire parent environment (previous behavior, opt-in) |
| `false` | Inherit nothing beyond explicitly provided `env` |
| `string[]` | Inherit the default allowlist plus the named variables |

```typescript
// Opt a specific variable back in
const git = await createGit({
  adapters: createNodeAdapters(),
  inheritEnv: ['MY_CUSTOM_VAR'],
});

// Restore the previous "inherit everything" behavior
const repo = await git.open('/path/to/repo', { inheritEnv: true });
```

## ⚠️ Breaking change

Workflows that relied on arbitrary parent environment variables reaching Git (e.g. a commit-signing or credential helper that reads a token from the environment) must now opt those variables back in via `inheritEnv`.

New exports: `EnvInheritance`, `DEFAULT_ENV_ALLOWLIST`, `resolveInheritedEnv`.

## Test plan

- [x] `pnpm test:ci` — 280 passed (added `env.test.ts` plus adapter/CliRunner inheritance tests)
- [x] `pnpm typecheck`
- [x] `pnpm check` (Biome lint + format)
- [x] `pnpm build`
- [x] Changeset added

> Note: the local sandbox forces `commit.gpgsign=true` with a signing helper that requires sandbox-specific environment variables. Since the allowlist (intentionally) strips those, the full test suite was verified green with signing disabled. Normal CI does not force signing, so this does not apply there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)