### PR TITLE
feat: inherit common Git transport config vars by default

### DIFF
--- a/.changeset/git-transport-env-allowlist.md
+++ b/.changeset/git-transport-env-allowlist.md
@@ -1,0 +1,11 @@
+---
+"type-git": patch
+---
+
+Add common Git transport configuration variables to the default environment allowlist
+
+Following the environment variable traversal prevention change, Git's own transport/TLS configuration variables were no longer inherited by default, which could break workflows relying on them (e.g. a custom SSH command).
+
+The default allowlist now also inherits these non-secret Git configuration variables: `GIT_SSH`, `GIT_SSH_COMMAND`, `GIT_SSH_VARIANT`, `GIT_SSL_CAINFO`, `GIT_SSL_CAPATH`, `GIT_PROXY_COMMAND`, `GIT_ASKPASS`, `SSH_ASKPASS`, `GIT_TERMINAL_PROMPT`, and `GIT_CONFIG_NOSYSTEM`.
+
+Application secrets remain excluded; use `inheritEnv` to opt any additional variables back in.

--- a/.changeset/git-transport-env-allowlist.md
+++ b/.changeset/git-transport-env-allowlist.md
@@ -4,8 +4,8 @@
 
 Add common Git transport configuration variables to the default environment allowlist
 
-Following the environment variable traversal prevention change, Git's own transport/TLS configuration variables were no longer inherited by default, which could break workflows relying on them (e.g. a custom SSH command).
+Following the environment variable traversal prevention change, Git's own SSH transport and TLS configuration variables were no longer inherited by default, which could break workflows relying on them (e.g. a custom SSH command).
 
-The default allowlist now also inherits these non-secret Git configuration variables: `GIT_SSH`, `GIT_SSH_COMMAND`, `GIT_SSH_VARIANT`, `GIT_SSL_CAINFO`, `GIT_SSL_CAPATH`, `GIT_PROXY_COMMAND`, `GIT_ASKPASS`, `SSH_ASKPASS`, `GIT_TERMINAL_PROMPT`, and `GIT_CONFIG_NOSYSTEM`.
+The default allowlist now also inherits these Git configuration variables, which are commonly needed for transport configuration: `GIT_SSH`, `GIT_SSH_COMMAND`, `GIT_SSH_VARIANT`, `GIT_SSL_CAINFO`, `GIT_SSL_CAPATH`, `GIT_TERMINAL_PROMPT`, and `GIT_CONFIG_NOSYSTEM`. These are configuration rather than application secrets (though, depending on local setup, values such as `GIT_SSH_COMMAND` may name a command Git executes).
 
-Application secrets remain excluded; use `inheritEnv` to opt any additional variables back in.
+Credential-carrying / askpass variables — `GIT_ASKPASS`, `SSH_ASKPASS`, and `GIT_PROXY_COMMAND` — are intentionally **not** inherited by default, since they can carry inline credentials or invoke a helper that reads secrets from the environment. Opt into those (and any other variables) explicitly via `inheritEnv` when needed.

--- a/src/core/env.test.ts
+++ b/src/core/env.test.ts
@@ -106,22 +106,28 @@ describe('resolveInheritedEnv', () => {
       expect(DEFAULT_ENV_ALLOWLIST).toContain('HOME');
     });
 
-    it('includes all common Git transport configuration variables', () => {
-      // Non-secret Git config vars needed for fetch/push to keep working by default
+    it('includes the SSH transport and TLS configuration variables', () => {
+      // Git config commonly needed for fetch/push to keep working by default
       const gitTransportVars = [
         'GIT_SSH',
         'GIT_SSH_COMMAND',
         'GIT_SSH_VARIANT',
         'GIT_SSL_CAINFO',
         'GIT_SSL_CAPATH',
-        'GIT_PROXY_COMMAND',
-        'GIT_ASKPASS',
-        'SSH_ASKPASS',
         'GIT_TERMINAL_PROMPT',
         'GIT_CONFIG_NOSYSTEM',
       ];
       for (const name of gitTransportVars) {
         expect(DEFAULT_ENV_ALLOWLIST).toContain(name);
+      }
+    });
+
+    it('excludes credential-carrying / askpass variables (opt-in only)', () => {
+      // These can carry inline credentials or run a helper that reads secrets from the
+      // environment, so they are not inherited by default to preserve the
+      // traversal-prevention model.
+      for (const name of ['GIT_ASKPASS', 'SSH_ASKPASS', 'GIT_PROXY_COMMAND']) {
+        expect(DEFAULT_ENV_ALLOWLIST).not.toContain(name);
       }
     });
   });
@@ -130,5 +136,12 @@ describe('resolveInheritedEnv', () => {
     const result = resolveInheritedEnv({ GIT_SSH_COMMAND: 'ssh -i /path/to/key' });
 
     expect(result.GIT_SSH_COMMAND).toBe('ssh -i /path/to/key');
+  });
+
+  it('does not inherit GIT_ASKPASS by default but can opt in', () => {
+    expect(resolveInheritedEnv({ GIT_ASKPASS: '/usr/bin/my-askpass' }).GIT_ASKPASS).toBeUndefined();
+
+    const optedIn = resolveInheritedEnv({ GIT_ASKPASS: '/usr/bin/my-askpass' }, ['GIT_ASKPASS']);
+    expect(optedIn.GIT_ASKPASS).toBe('/usr/bin/my-askpass');
   });
 });

--- a/src/core/env.test.ts
+++ b/src/core/env.test.ts
@@ -106,11 +106,23 @@ describe('resolveInheritedEnv', () => {
       expect(DEFAULT_ENV_ALLOWLIST).toContain('HOME');
     });
 
-    it('includes common Git transport configuration variables', () => {
+    it('includes all common Git transport configuration variables', () => {
       // Non-secret Git config vars needed for fetch/push to keep working by default
-      expect(DEFAULT_ENV_ALLOWLIST).toContain('GIT_SSH_COMMAND');
-      expect(DEFAULT_ENV_ALLOWLIST).toContain('GIT_SSL_CAINFO');
-      expect(DEFAULT_ENV_ALLOWLIST).toContain('GIT_PROXY_COMMAND');
+      const gitTransportVars = [
+        'GIT_SSH',
+        'GIT_SSH_COMMAND',
+        'GIT_SSH_VARIANT',
+        'GIT_SSL_CAINFO',
+        'GIT_SSL_CAPATH',
+        'GIT_PROXY_COMMAND',
+        'GIT_ASKPASS',
+        'SSH_ASKPASS',
+        'GIT_TERMINAL_PROMPT',
+        'GIT_CONFIG_NOSYSTEM',
+      ];
+      for (const name of gitTransportVars) {
+        expect(DEFAULT_ENV_ALLOWLIST).toContain(name);
+      }
     });
   });
 

--- a/src/core/env.test.ts
+++ b/src/core/env.test.ts
@@ -105,5 +105,18 @@ describe('resolveInheritedEnv', () => {
       expect(DEFAULT_ENV_ALLOWLIST).toContain('PATH');
       expect(DEFAULT_ENV_ALLOWLIST).toContain('HOME');
     });
+
+    it('includes common Git transport configuration variables', () => {
+      // Non-secret Git config vars needed for fetch/push to keep working by default
+      expect(DEFAULT_ENV_ALLOWLIST).toContain('GIT_SSH_COMMAND');
+      expect(DEFAULT_ENV_ALLOWLIST).toContain('GIT_SSL_CAINFO');
+      expect(DEFAULT_ENV_ALLOWLIST).toContain('GIT_PROXY_COMMAND');
+    });
+  });
+
+  it('inherits a custom GIT_SSH_COMMAND by default', () => {
+    const result = resolveInheritedEnv({ GIT_SSH_COMMAND: 'ssh -i /path/to/key' });
+
+    expect(result.GIT_SSH_COMMAND).toBe('ssh -i /path/to/key');
   });
 });

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -65,13 +65,14 @@ export const DEFAULT_ENV_ALLOWLIST: readonly string[] = [
   'SSH_AUTH_SOCK',
   'SSH_AGENT_PID',
   // Git SSH transport and TLS configuration. These are commonly required for
-  // fetch/push to keep working under the default allowlist. They are configuration
-  // (not application secrets), though GIT_SSH_COMMAND can name a command Git executes.
-  // Credential-carrying / askpass variables (GIT_ASKPASS, SSH_ASKPASS,
-  // GIT_PROXY_COMMAND) are intentionally NOT inherited by default — they can carry
-  // inline credentials or run a helper that reads secrets from the environment, which
-  // would weaken the traversal-prevention model. Opt into those explicitly via
-  // `inheritEnv` when needed.
+  // fetch/push to keep working under the default allowlist. They are transport
+  // configuration rather than credential stores, but note they can still carry
+  // sensitive data depending on local setup (e.g. GIT_SSH_COMMAND can name a command
+  // Git executes). The most credential-prone / askpass variables (GIT_ASKPASS,
+  // SSH_ASKPASS, GIT_PROXY_COMMAND) are intentionally NOT inherited by default — they
+  // can carry inline credentials or run a helper that reads secrets from the
+  // environment, which would weaken the traversal-prevention model. Opt into those
+  // explicitly via `inheritEnv` when needed.
   'GIT_SSH',
   'GIT_SSH_COMMAND',
   'GIT_SSH_VARIANT',

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -64,16 +64,19 @@ export const DEFAULT_ENV_ALLOWLIST: readonly string[] = [
   // SSH agent (required for Git-over-SSH authentication)
   'SSH_AUTH_SOCK',
   'SSH_AGENT_PID',
-  // Git transport / TLS / askpass configuration (non-secret; commonly required for
-  // network operations such as fetch/push to keep working under the default allowlist)
+  // Git SSH transport and TLS configuration. These are commonly required for
+  // fetch/push to keep working under the default allowlist. They are configuration
+  // (not application secrets), though GIT_SSH_COMMAND can name a command Git executes.
+  // Credential-carrying / askpass variables (GIT_ASKPASS, SSH_ASKPASS,
+  // GIT_PROXY_COMMAND) are intentionally NOT inherited by default — they can carry
+  // inline credentials or run a helper that reads secrets from the environment, which
+  // would weaken the traversal-prevention model. Opt into those explicitly via
+  // `inheritEnv` when needed.
   'GIT_SSH',
   'GIT_SSH_COMMAND',
   'GIT_SSH_VARIANT',
   'GIT_SSL_CAINFO',
   'GIT_SSL_CAPATH',
-  'GIT_PROXY_COMMAND',
-  'GIT_ASKPASS',
-  'SSH_ASKPASS',
   'GIT_TERMINAL_PROMPT',
   'GIT_CONFIG_NOSYSTEM',
   // HTTP(S) proxy configuration (required for Git network operations behind a proxy)

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -64,6 +64,18 @@ export const DEFAULT_ENV_ALLOWLIST: readonly string[] = [
   // SSH agent (required for Git-over-SSH authentication)
   'SSH_AUTH_SOCK',
   'SSH_AGENT_PID',
+  // Git transport / TLS / askpass configuration (non-secret; commonly required for
+  // network operations such as fetch/push to keep working under the default allowlist)
+  'GIT_SSH',
+  'GIT_SSH_COMMAND',
+  'GIT_SSH_VARIANT',
+  'GIT_SSL_CAINFO',
+  'GIT_SSL_CAPATH',
+  'GIT_PROXY_COMMAND',
+  'GIT_ASKPASS',
+  'SSH_ASKPASS',
+  'GIT_TERMINAL_PROMPT',
+  'GIT_CONFIG_NOSYSTEM',
   // HTTP(S) proxy configuration (required for Git network operations behind a proxy)
   'HTTP_PROXY',
   'HTTPS_PROXY',


### PR DESCRIPTION
## Summary

Follow-up to #115 (environment variable traversal prevention).

After that change, Git's own SSH transport / TLS configuration variables were no longer inherited by default, which could break workflows that rely on them — most notably a custom `GIT_SSH_COMMAND` for `fetch`/`push`. This PR restores the commonly needed **configuration** variables to the default allowlist while deliberately keeping credential-carrying variables opt-in, so the traversal-prevention model stays intact.

## Changes

- Add to `DEFAULT_ENV_ALLOWLIST` (SSH transport + TLS config; commonly needed, configuration rather than secrets):
  - `GIT_SSH`, `GIT_SSH_COMMAND`, `GIT_SSH_VARIANT`
  - `GIT_SSL_CAINFO`, `GIT_SSL_CAPATH`
  - `GIT_TERMINAL_PROMPT`, `GIT_CONFIG_NOSYSTEM`
- **Intentionally kept opt-in (NOT in the default allowlist):** `GIT_ASKPASS`, `SSH_ASKPASS`, `GIT_PROXY_COMMAND` — these can carry inline credentials or invoke a helper that reads secrets from the environment, so inheriting them by default would weaken traversal prevention. Opt in explicitly via `inheritEnv` when needed.
- Tests: assert the transport/TLS vars are present, the askpass/proxy vars are absent by default, and that an askpass var can be opted in via `inheritEnv`.
- Wording: dropped the "non-secret" framing in code/tests/changeset; these values are commonly needed for transport config but can still carry sensitive data depending on local setup.

## Security note

This keeps the strict default from #115: application secrets and credential-providing helpers are not forwarded to Git subprocesses unless explicitly opted in. Only passive SSH/TLS transport configuration is inherited by default.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm check` (Biome lint + format)
- [x] `pnpm exec vitest run src/core/env.test.ts` — 14 passed
- [x] Changeset added (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)