### PR TITLE
test: add Deno/Bun smoke tests for inheritEnv env isolation

### DIFF
--- a/test/bun/smoke.test.ts
+++ b/test/bun/smoke.test.ts
@@ -73,6 +73,36 @@ describe('BunExecAdapter', () => {
       expect(result.stdout.trim()).toBe('test_value');
     });
 
+    test('does not leak the parent environment when inheritEnv is false', async () => {
+      process.env.TYPE_GIT_SMOKE_SECRET = 'leaked';
+      try {
+        const result = await adapter.spawn({
+          // Provide PATH so `sh` can still be located, but nothing else.
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          env: { PATH: process.env.PATH ?? '' },
+          inheritEnv: false,
+        });
+
+        expect(result.stdout.trim()).toBe('undefined');
+      } finally {
+        delete process.env.TYPE_GIT_SMOKE_SECRET;
+      }
+    });
+
+    test('inherits the parent environment by default', async () => {
+      process.env.TYPE_GIT_SMOKE_SECRET = 'inherited';
+      try {
+        const result = await adapter.spawn({
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          env: { OTHER: 'x' },
+        });
+
+        expect(result.stdout.trim()).toBe('inherited');
+      } finally {
+        delete process.env.TYPE_GIT_SMOKE_SECRET;
+      }
+    });
+
     test('handles abort signal', async () => {
       const controller = new AbortController();
 

--- a/test/bun/smoke.test.ts
+++ b/test/bun/smoke.test.ts
@@ -74,32 +74,34 @@ describe('BunExecAdapter', () => {
     });
 
     test('does not leak the parent environment when inheritEnv is false', async () => {
-      process.env.TYPE_GIT_SMOKE_SECRET = 'leaked';
+      // Use a test-specific var name to avoid races with concurrently running tests.
+      process.env.TYPE_GIT_SMOKE_NOLEAK = 'leaked';
       try {
         const result = await adapter.spawn({
           // Provide PATH so `sh` can still be located, but nothing else.
-          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_NOLEAK:-undefined}"'],
           env: { PATH: process.env.PATH ?? '' },
           inheritEnv: false,
         });
 
         expect(result.stdout.trim()).toBe('undefined');
       } finally {
-        delete process.env.TYPE_GIT_SMOKE_SECRET;
+        delete process.env.TYPE_GIT_SMOKE_NOLEAK;
       }
     });
 
     test('inherits the parent environment by default', async () => {
-      process.env.TYPE_GIT_SMOKE_SECRET = 'inherited';
+      // Use a test-specific var name to avoid races with concurrently running tests.
+      process.env.TYPE_GIT_SMOKE_INHERIT = 'inherited';
       try {
         const result = await adapter.spawn({
-          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_INHERIT:-undefined}"'],
           env: { OTHER: 'x' },
         });
 
         expect(result.stdout.trim()).toBe('inherited');
       } finally {
-        delete process.env.TYPE_GIT_SMOKE_SECRET;
+        delete process.env.TYPE_GIT_SMOKE_INHERIT;
       }
     });
 

--- a/test/deno/smoke.test.ts
+++ b/test/deno/smoke.test.ts
@@ -82,6 +82,38 @@ describe('DenoExecAdapter', () => {
       assertEquals(result.stdout.trim(), 'test_value');
     });
 
+    it('does not leak the parent environment when inheritEnv is false', async () => {
+      Deno.env.set('TYPE_GIT_SMOKE_SECRET', 'leaked');
+      try {
+        const result = await adapter.spawn({
+          // Provide PATH so `sh` can still be located, but nothing else.
+          // Deno only clears the parent environment when clearEnv is set, which the
+          // adapter does for inheritEnv: false.
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          env: { PATH: Deno.env.get('PATH') ?? '' },
+          inheritEnv: false,
+        });
+
+        assertEquals(result.stdout.trim(), 'undefined');
+      } finally {
+        Deno.env.delete('TYPE_GIT_SMOKE_SECRET');
+      }
+    });
+
+    it('inherits the parent environment by default', async () => {
+      Deno.env.set('TYPE_GIT_SMOKE_SECRET', 'inherited');
+      try {
+        const result = await adapter.spawn({
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          env: { OTHER: 'x' },
+        });
+
+        assertEquals(result.stdout.trim(), 'inherited');
+      } finally {
+        Deno.env.delete('TYPE_GIT_SMOKE_SECRET');
+      }
+    });
+
     it('handles abort signal', async () => {
       const controller = new AbortController();
 

--- a/test/deno/smoke.test.ts
+++ b/test/deno/smoke.test.ts
@@ -83,34 +83,36 @@ describe('DenoExecAdapter', () => {
     });
 
     it('does not leak the parent environment when inheritEnv is false', async () => {
-      Deno.env.set('TYPE_GIT_SMOKE_SECRET', 'leaked');
+      // Use a test-specific var name to avoid races with concurrently running tests.
+      Deno.env.set('TYPE_GIT_SMOKE_NOLEAK', 'leaked');
       try {
         const result = await adapter.spawn({
           // Provide PATH so `sh` can still be located, but nothing else.
           // Deno only clears the parent environment when clearEnv is set, which the
           // adapter does for inheritEnv: false.
-          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_NOLEAK:-undefined}"'],
           env: { PATH: Deno.env.get('PATH') ?? '' },
           inheritEnv: false,
         });
 
         assertEquals(result.stdout.trim(), 'undefined');
       } finally {
-        Deno.env.delete('TYPE_GIT_SMOKE_SECRET');
+        Deno.env.delete('TYPE_GIT_SMOKE_NOLEAK');
       }
     });
 
     it('inherits the parent environment by default', async () => {
-      Deno.env.set('TYPE_GIT_SMOKE_SECRET', 'inherited');
+      // Use a test-specific var name to avoid races with concurrently running tests.
+      Deno.env.set('TYPE_GIT_SMOKE_INHERIT', 'inherited');
       try {
         const result = await adapter.spawn({
-          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_SECRET:-undefined}"'],
+          argv: ['sh', '-c', 'echo "${TYPE_GIT_SMOKE_INHERIT:-undefined}"'],
           env: { OTHER: 'x' },
         });
 
         assertEquals(result.stdout.trim(), 'inherited');
       } finally {
-        Deno.env.delete('TYPE_GIT_SMOKE_SECRET');
+        Deno.env.delete('TYPE_GIT_SMOKE_INHERIT');
       }
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #115 (environment variable traversal prevention).

The no-leak behavior under `inheritEnv: false` was only covered by the **Node** adapter tests. The Deno path is the trickiest one (Deno's `Deno.Command` merges the parent environment unless `clearEnv: true` is set), so it deserves explicit coverage. This PR adds equivalent **Bun** and **Deno** smoke tests.

## Changes

- `test/bun/smoke.test.ts` and `test/deno/smoke.test.ts`: add two `spawn` tests each
  - asserts the parent environment is **not** leaked when `inheritEnv: false` (exercising Deno's `clearEnv` path)
  - asserts the parent environment **is** inherited by default

Tests only — no source or behavior changes, so no changeset.

## Test plan

- [x] `bun test test/bun/smoke.test.ts -t "parent environment"` — 2 passed
- [ ] Deno suite runs in CI (`pnpm test:deno`, which already passes `--allow-env`); Deno is not installed in the authoring sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0147LvY8TxMbg2oqUNZgKPav)_