### PR TITLE
fix: forward onLfsProgress through pull and LFS transfer operations

### DIFF
--- a/.changeset/lfs-progress-pull-fetch-preupload.md
+++ b/.changeset/lfs-progress-pull-fetch-preupload.md
@@ -1,0 +1,15 @@
+---
+"type-git": minor
+---
+
+Forward `onLfsProgress` through `pull` and the LFS transfer operations
+
+`onLfsProgress` was accepted on these methods' option types (via `ExecOpts`)
+but was never wired to the runner, so the callback silently never fired.
+LFS transfer progress is now reported during `repo.pull()`, `repo.lfs.pull()`,
+`repo.lfs.push()`, `repo.lfs.fetch()`, `repo.lfsExtra.preUpload()` and
+`repo.lfsExtra.preDownload()`, matching the existing `clone` / `push` behavior.
+
+The `--progress` enablement gate was also broadened from `onProgress` to
+`onProgress || onLfsProgress` (in `clone`, `push`, `pull` and `lfs.fetch`) so
+that passing only `onLfsProgress` still requests progress output.

--- a/src/impl/bare-repo-impl.ts
+++ b/src/impl/bare-repo-impl.ts
@@ -630,7 +630,7 @@ export class BareRepoImpl implements BareRepo {
   public async push(opts?: PushOpts & ExecOpts): Promise<void> {
     const args = ['push'];
 
-    if (opts?.onProgress) {
+    if (opts?.onProgress || opts?.onLfsProgress) {
       args.push('--progress');
     }
 

--- a/src/impl/git-impl.ts
+++ b/src/impl/git-impl.ts
@@ -374,8 +374,9 @@ export class GitImpl implements Git {
   ): Promise<WorktreeRepo | BareRepo> {
     const args = buildCloneArgs(opts);
 
-    // Add progress flag for progress tracking (from ExecOpts)
-    if (opts?.onProgress) {
+    // Add progress flag for progress tracking (from ExecOpts).
+    // LFS progress is delivered via stderr too, so enable it for onLfsProgress as well.
+    if (opts?.onProgress || opts?.onLfsProgress) {
       args.push('--progress');
     }
 

--- a/src/impl/lfs-progress-wiring.test.ts
+++ b/src/impl/lfs-progress-wiring.test.ts
@@ -60,9 +60,11 @@ describe('onLfsProgress wiring', () => {
 
     expect(events.length).toBeGreaterThan(0);
     expect(events[0]).toMatchObject({ direction: 'download', percent: 50 });
-    // LFS progress output is enabled via env var, independent of --progress.
+    // `--progress` is added when only onLfsProgress is set, and LFS progress
+    // output is additionally forced via GIT_LFS_FORCE_PROGRESS.
     expect(adapters.exec.spawn).toHaveBeenCalledWith(
       expect.objectContaining({
+        argv: expect.arrayContaining(['--progress']),
         env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
       }),
       expect.objectContaining({ onStderr: expect.any(Function) }),
@@ -79,6 +81,7 @@ describe('onLfsProgress wiring', () => {
     expect(events.length).toBeGreaterThan(0);
     expect(adapters.exec.spawn).toHaveBeenCalledWith(
       expect.objectContaining({
+        argv: expect.arrayContaining(['--progress']),
         env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
       }),
       expect.objectContaining({ onStderr: expect.any(Function) }),
@@ -95,6 +98,7 @@ describe('onLfsProgress wiring', () => {
     expect(events.length).toBeGreaterThan(0);
     expect(adapters.exec.spawn).toHaveBeenCalledWith(
       expect.objectContaining({
+        argv: expect.arrayContaining(['--progress']),
         env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
       }),
       expect.objectContaining({ onStderr: expect.any(Function) }),
@@ -109,14 +113,20 @@ describe('onLfsProgress wiring', () => {
     await repo.pull({ onLfsProgress: (p) => events.push(p) });
 
     expect(events.length).toBeGreaterThan(0);
+    // The progress gate is broadened to onProgress || onLfsProgress, so
+    // `--progress` must be added even though only onLfsProgress is provided.
     expect(adapters.exec.spawn).toHaveBeenCalledWith(
       expect.objectContaining({
+        argv: expect.arrayContaining(['--progress']),
         env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
       }),
       expect.objectContaining({ onStderr: expect.any(Function) }),
     );
   });
 
+  // `git lfs pull/push` (and the batched preUpload/preDownload helpers) do not
+  // take a `--progress` flag; LFS progress is forced purely via the
+  // GIT_LFS_FORCE_PROGRESS env var, so these tests assert only on that.
   it('lfs.pull forwards onLfsProgress to the runner', async () => {
     const adapters = createMockAdapters();
     const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo');
@@ -157,8 +167,11 @@ describe('onLfsProgress wiring', () => {
     await repo.lfs.fetch({ onLfsProgress: (p) => events.push(p) });
 
     expect(events.length).toBeGreaterThan(0);
+    // `git lfs fetch` does take `--progress`; the broadened gate must add it
+    // when only onLfsProgress is provided.
     expect(adapters.exec.spawn).toHaveBeenCalledWith(
       expect.objectContaining({
+        argv: expect.arrayContaining(['--progress']),
         env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
       }),
       expect.objectContaining({ onStderr: expect.any(Function) }),

--- a/src/impl/lfs-progress-wiring.test.ts
+++ b/src/impl/lfs-progress-wiring.test.ts
@@ -1,5 +1,7 @@
 /**
- * Tests that `onLfsProgress` is forwarded from clone / push down to the runner.
+ * Tests that `onLfsProgress` is forwarded from clone / push / pull and the LFS
+ * transfer operations (lfs.pull, lfs.push, lfs.fetch, lfsExtra.preUpload,
+ * lfsExtra.preDownload) down to the runner.
  *
  * These use mock adapters (rather than a real git binary) so that LFS transfer
  * progress lines can be simulated deterministically on stderr.
@@ -89,6 +91,110 @@ describe('onLfsProgress wiring', () => {
     const events: LfsProgress[] = [];
 
     await repo.push({ onLfsProgress: (p) => events.push(p) });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(adapters.exec.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
+      }),
+      expect.objectContaining({ onStderr: expect.any(Function) }),
+    );
+  });
+
+  it('pull forwards onLfsProgress to the runner', async () => {
+    const adapters = createMockAdapters();
+    const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo');
+    const events: LfsProgress[] = [];
+
+    await repo.pull({ onLfsProgress: (p) => events.push(p) });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(adapters.exec.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
+      }),
+      expect.objectContaining({ onStderr: expect.any(Function) }),
+    );
+  });
+
+  it('lfs.pull forwards onLfsProgress to the runner', async () => {
+    const adapters = createMockAdapters();
+    const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo');
+    const events: LfsProgress[] = [];
+
+    await repo.lfs.pull({ onLfsProgress: (p) => events.push(p) });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(adapters.exec.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
+      }),
+      expect.objectContaining({ onStderr: expect.any(Function) }),
+    );
+  });
+
+  it('lfs.push forwards onLfsProgress to the runner', async () => {
+    const adapters = createMockAdapters();
+    const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo');
+    const events: LfsProgress[] = [];
+
+    await repo.lfs.push({ onLfsProgress: (p) => events.push(p) });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(adapters.exec.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
+      }),
+      expect.objectContaining({ onStderr: expect.any(Function) }),
+    );
+  });
+
+  it('lfs.fetch forwards onLfsProgress to the runner', async () => {
+    const adapters = createMockAdapters();
+    const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo');
+    const events: LfsProgress[] = [];
+
+    await repo.lfs.fetch({ onLfsProgress: (p) => events.push(p) });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(adapters.exec.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
+      }),
+      expect.objectContaining({ onStderr: expect.any(Function) }),
+    );
+  });
+
+  it('lfsExtra.preUpload forwards onLfsProgress to the runner', async () => {
+    const adapters = createMockAdapters();
+    const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo');
+    const events: LfsProgress[] = [];
+
+    // Provide explicit OIDs so the batched `git lfs push` runs (skips ls-files).
+    await repo.lfsExtra.preUpload({
+      oids: ['a'.repeat(64)],
+      onLfsProgress: (p) => events.push(p),
+    });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(adapters.exec.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ GIT_LFS_FORCE_PROGRESS: '1' }),
+      }),
+      expect.objectContaining({ onStderr: expect.any(Function) }),
+    );
+  });
+
+  it('lfsExtra.preDownload forwards onLfsProgress to the runner', async () => {
+    const adapters = createMockAdapters();
+    const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo');
+    const events: LfsProgress[] = [];
+
+    // Provide explicit OIDs so the batched `git lfs fetch` runs (skips ls-files).
+    await repo.lfsExtra.preDownload({
+      oids: ['a'.repeat(64)],
+      onLfsProgress: (p) => events.push(p),
+    });
 
     expect(events.length).toBeGreaterThan(0);
     expect(adapters.exec.spawn).toHaveBeenCalledWith(

--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -913,8 +913,8 @@ export class WorktreeRepoImpl implements WorktreeRepo {
   public async push(opts?: PushOpts & ExecOpts): Promise<void> {
     const args = ['push'];
 
-    // Progress tracking
-    if (opts?.onProgress) {
+    // Progress tracking (git and/or LFS progress are streamed over stderr)
+    if (opts?.onProgress || opts?.onLfsProgress) {
       args.push('--progress');
     }
 
@@ -1094,6 +1094,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
+      onLfsProgress: opts?.onLfsProgress,
     });
   }
 
@@ -1131,6 +1132,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
+      onLfsProgress: opts?.onLfsProgress,
     });
   }
 
@@ -1238,6 +1240,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       const result = await this.runner.run(this.context, args, {
         signal: opts?.signal,
         onProgress: opts?.onProgress,
+        onLfsProgress: opts?.onLfsProgress,
       });
 
       if (result.exitCode === 0) {
@@ -1337,6 +1340,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
       const result = await this.runner.run(this.context, args, {
         signal: opts?.signal,
         onProgress: opts?.onProgress,
+        onLfsProgress: opts?.onLfsProgress,
       });
 
       if (result.exitCode === 0) {
@@ -1418,7 +1422,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
 
     const args = ['lfs', 'fetch'];
 
-    if (opts?.onProgress) {
+    if (opts?.onProgress || opts?.onLfsProgress) {
       args.push('--progress');
     }
 
@@ -1460,6 +1464,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
+      onLfsProgress: opts?.onLfsProgress,
     });
   }
 
@@ -3016,8 +3021,8 @@ export class WorktreeRepoImpl implements WorktreeRepo {
   public async pull(opts?: PullOpts & ExecOpts): Promise<void> {
     const args = ['pull'];
 
-    // Progress tracking
-    if (opts?.onProgress) {
+    // Progress tracking (git and/or LFS progress are streamed over stderr)
+    if (opts?.onProgress || opts?.onLfsProgress) {
       args.push('--progress');
     }
 
@@ -3213,6 +3218,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
+      onLfsProgress: opts?.onLfsProgress,
     });
   }
 


### PR DESCRIPTION
## Summary

`onLfsProgress` is accepted on every method's options (via `ExecOpts`), but several LFS-relevant methods forwarded only `onProgress` to the runner and dropped `onLfsProgress`. Because it type-checks fine, callers reasonably expect progress events, but the callback **silently never fires** at runtime — only `clone` (and the regular `push`) forwarded it.

This wires `onLfsProgress` through the remaining LFS transfer operations and broadens the `--progress` enablement gate.

### Methods fixed (now forward `onLfsProgress` to the runner)
- `repo.pull()` — *(reported)*
- `repo.lfsExtra.preUpload()` — *(reported)* (batched `git lfs push --object-id`)
- `repo.lfs.fetch()` — *(reported)*
- `repo.lfs.pull()` — identical latent bug
- `repo.lfs.push()` — identical latent bug
- `repo.lfsExtra.preDownload()` — identical latent bug (batched `git lfs fetch`)

The three explicitly reported methods were fixed; the other three had the exact same one-line omission, so they're fixed here too to avoid leaving the asymmetry in place.

### Progress gate broadened
The `--progress` flag was previously added only when `onProgress` was set. It's now gated on `onProgress || onLfsProgress` in `clone`, `push` (worktree + bare), `pull`, and `lfs.fetch`, so passing only `onLfsProgress` still requests progress output. (LFS progress itself is forced via `GIT_LFS_FORCE_PROGRESS=1`, which the runner already sets from `onLfsProgress`.)

## Test plan
- [x] Added wiring tests in `src/impl/lfs-progress-wiring.test.ts` for `pull`, `lfs.pull`, `lfs.push`, `lfs.fetch`, `lfsExtra.preUpload`, `lfsExtra.preDownload` (assert events fire + `GIT_LFS_FORCE_PROGRESS=1` env + stderr streaming).
- [x] `pnpm typecheck`
- [x] `pnpm test:ci` (286 passed)
- [x] `pnpm check` (no new warnings)
- [x] Changeset added (`minor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SXWDUQPS6wQF8rRCRFmtr

---
_Generated by [Claude Code](https://claude.ai/code/session_011SXWDUQPS6wQF8rRCRFmtr)_