### PR TITLE
feat: honor object-form LFS mode (skipSmudge / skipDownload)

### DIFF
--- a/.changeset/lfs-skip-smudge-mode.md
+++ b/.changeset/lfs-skip-smudge-mode.md
@@ -1,0 +1,19 @@
+---
+"type-git": minor
+---
+
+Honor the object-form LFS mode (`open({ lfs: { skipSmudge } })`)
+
+Previously the object form of `LfsMode` (`{ skipSmudge?, skipDownload? }`) was
+stored but never consulted — only the string `'disabled'` had any effect, so
+`open({ lfs: { skipSmudge: true } })` was a silent no-op and checkout/pull still
+smudged LFS files.
+
+Now, when a repository is opened (or reconfigured via `setLfsMode`) with an
+object-form mode requesting `skipSmudge` and/or `skipDownload`, the
+working-tree-populating operations — `checkout`, `switch`, `reset`, `merge`,
+`pull`, `rebase` and `restore` — run with `GIT_LFS_SKIP_SMUDGE=1`. Git leaves
+LFS pointer files in place instead of downloading their contents. The objects
+can be materialized later via the explicit `repo.lfs.pull()` /
+`repo.lfs.checkout()` helpers, which use dedicated git-lfs commands and are not
+affected by the variable.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -301,15 +301,23 @@ export type Capabilities = {
 // =============================================================================
 
 /**
- * LFS mode configuration
+ * LFS mode configuration.
+ *
+ * - `'enabled'` (default): LFS behaves normally.
+ * - `'disabled'`: the `repo.lfs.*` / `repo.lfsExtra.*` helpers become no-ops.
+ * - object form: working-tree-populating operations (`checkout`, `switch`,
+ *   `reset`, `merge`, `pull`, `rebase`, `restore`) run with
+ *   `GIT_LFS_SKIP_SMUDGE=1` so Git leaves LFS pointer files in place instead of
+ *   downloading their contents. The objects can be materialized later via the
+ *   explicit `repo.lfs.pull()` / `repo.lfs.checkout()` helpers.
  */
 export type LfsMode =
   | 'enabled'
   | 'disabled'
   | {
-      /** Skip smudge filter (don't download LFS files on checkout) */
+      /** Skip smudge filter (don't download LFS files on checkout). */
       skipSmudge?: boolean;
-      /** Skip download (keep pointer files) */
+      /** Skip download, keeping pointer files (also implies skip-smudge). */
       skipDownload?: boolean;
     };
 

--- a/src/impl/lfs-skip-smudge.test.ts
+++ b/src/impl/lfs-skip-smudge.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests that an object-form LFS mode (`{ skipSmudge }` / `{ skipDownload }`)
+ * injects `GIT_LFS_SKIP_SMUDGE=1` into the environment of working-tree-populating
+ * operations so Git leaves LFS pointer files in place instead of downloading them.
+ *
+ * Uses mock adapters so the spawned environment can be inspected directly.
+ */
+
+import { describe, expect, it, type Mock, vi } from 'vitest';
+import type { RuntimeAdapters } from '../core/adapters.js';
+import type { LfsMode } from '../core/types.js';
+import { CliRunner } from '../runner/cli-runner.js';
+import { WorktreeRepoImpl } from './worktree-repo-impl.js';
+
+function createMockAdapters(): RuntimeAdapters {
+  return {
+    exec: {
+      getCapabilities: () => ({
+        canSpawnProcess: true,
+        canReadEnv: true,
+        canWriteTemp: true,
+        supportsAbortSignal: true,
+        supportsKillSignal: true,
+        runtime: 'node' as const,
+      }),
+      // Exit 0 for everything; merge etc. follow their success path.
+      spawn: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0, aborted: false }),
+    },
+    fs: {
+      createTempFile: vi.fn().mockResolvedValue('/tmp/type-git-lfs-123/temp'),
+      tail: vi.fn().mockResolvedValue(undefined),
+      deleteFile: vi.fn().mockResolvedValue(undefined),
+      deleteDirectory: vi.fn().mockResolvedValue(undefined),
+      exists: vi.fn().mockResolvedValue(true),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+// Find the environment of the spawn call whose argv contains the given subcommand.
+function envForSubcommand(spawn: Mock, subcommand: string): Record<string, string> | undefined {
+  const call = spawn.mock.calls.find((args) => {
+    const opts = args[0] as { argv?: string[] };
+    return Array.isArray(opts.argv) && opts.argv.includes(subcommand);
+  });
+  return (call?.[0] as { env?: Record<string, string> } | undefined)?.env;
+}
+
+function makeRepo(lfs?: LfsMode): { repo: WorktreeRepoImpl; spawn: Mock } {
+  const adapters = createMockAdapters();
+  const repo = new WorktreeRepoImpl(new CliRunner(adapters), '/repo', lfs ? { lfs } : undefined);
+  return { repo, spawn: adapters.exec.spawn as Mock };
+}
+
+// Each entry: subcommand token in argv + how to invoke it on the repo.
+const SMUDGE_OPERATIONS: ReadonlyArray<{
+  name: string;
+  subcommand: string;
+  run: (repo: WorktreeRepoImpl) => Promise<unknown>;
+}> = [
+  { name: 'checkout', subcommand: 'checkout', run: (r) => r.checkout('feature') },
+  { name: 'switch', subcommand: 'switch', run: (r) => r.switch('feature') },
+  { name: 'reset', subcommand: 'reset', run: (r) => r.reset('HEAD', { mode: 'hard' }) },
+  { name: 'merge', subcommand: 'merge', run: (r) => r.merge('feature') },
+  { name: 'pull', subcommand: 'pull', run: (r) => r.pull() },
+  { name: 'rebase', subcommand: 'rebase', run: (r) => r.rebase({ upstream: 'main' }) },
+  { name: 'restore', subcommand: 'restore', run: (r) => r.restore(['file.txt']) },
+];
+
+describe('LFS skip-smudge mode', () => {
+  describe('injects GIT_LFS_SKIP_SMUDGE=1 with { skipSmudge: true }', () => {
+    for (const op of SMUDGE_OPERATIONS) {
+      it(`${op.name} runs with GIT_LFS_SKIP_SMUDGE=1`, async () => {
+        const { repo, spawn } = makeRepo({ skipSmudge: true });
+        await op.run(repo);
+        expect(envForSubcommand(spawn, op.subcommand)).toMatchObject({
+          GIT_LFS_SKIP_SMUDGE: '1',
+        });
+      });
+    }
+  });
+
+  it('also injects GIT_LFS_SKIP_SMUDGE=1 with { skipDownload: true }', async () => {
+    const { repo, spawn } = makeRepo({ skipDownload: true });
+    await repo.checkout('feature');
+    expect(envForSubcommand(spawn, 'checkout')).toMatchObject({ GIT_LFS_SKIP_SMUDGE: '1' });
+  });
+
+  it("does not set GIT_LFS_SKIP_SMUDGE for the 'enabled' mode", async () => {
+    const { repo, spawn } = makeRepo('enabled');
+    await repo.checkout('feature');
+    expect(envForSubcommand(spawn, 'checkout')?.GIT_LFS_SKIP_SMUDGE).toBeUndefined();
+  });
+
+  it("does not set GIT_LFS_SKIP_SMUDGE for the 'disabled' mode", async () => {
+    const { repo, spawn } = makeRepo('disabled');
+    await repo.checkout('feature');
+    expect(envForSubcommand(spawn, 'checkout')?.GIT_LFS_SKIP_SMUDGE).toBeUndefined();
+  });
+
+  it('does not set GIT_LFS_SKIP_SMUDGE for an empty object mode', async () => {
+    const { repo, spawn } = makeRepo({});
+    await repo.checkout('feature');
+    expect(envForSubcommand(spawn, 'checkout')?.GIT_LFS_SKIP_SMUDGE).toBeUndefined();
+  });
+
+  it('honors setLfsMode() changes at runtime', async () => {
+    const { repo, spawn } = makeRepo('enabled');
+
+    await repo.checkout('a');
+    expect(envForSubcommand(spawn, 'checkout')?.GIT_LFS_SKIP_SMUDGE).toBeUndefined();
+
+    repo.setLfsMode({ skipSmudge: true });
+    spawn.mockClear();
+
+    await repo.checkout('b');
+    expect(envForSubcommand(spawn, 'checkout')).toMatchObject({ GIT_LFS_SKIP_SMUDGE: '1' });
+  });
+
+  it('does not inject GIT_LFS_SKIP_SMUDGE into non-smudge operations like status', async () => {
+    const { repo, spawn } = makeRepo({ skipSmudge: true });
+    await repo.status();
+    expect(envForSubcommand(spawn, 'status')?.GIT_LFS_SKIP_SMUDGE).toBeUndefined();
+  });
+});

--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -3239,6 +3239,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
+      onLfsProgress: opts?.onLfsProgress,
       env: this.lfsModeEnv(),
     });
   }

--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -1064,6 +1064,30 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     this._lfsMode = mode;
   }
 
+  /**
+   * Per-command environment overrides derived from the configured LFS mode.
+   *
+   * When the repository was opened (or reconfigured) with an object-form LFS
+   * mode requesting `skipSmudge` and/or `skipDownload`, working-tree-populating
+   * operations (checkout, switch, reset, merge, pull, restore) run with
+   * `GIT_LFS_SKIP_SMUDGE=1`. Git then leaves LFS pointer files in place instead
+   * of downloading their contents during the implicit checkout.
+   *
+   * The objects can be materialized later via the explicit `repo.lfs.pull()` /
+   * `repo.lfs.checkout()` helpers, which use dedicated git-lfs commands and are
+   * not affected by `GIT_LFS_SKIP_SMUDGE`.
+   *
+   * Returns `undefined` for the `'enabled'` / `'disabled'` string modes so the
+   * runner environment is left untouched.
+   */
+  private lfsModeEnv(): Record<string, string> | undefined {
+    const mode = this._lfsMode;
+    if (typeof mode === 'object' && (mode.skipSmudge === true || mode.skipDownload === true)) {
+      return { GIT_LFS_SKIP_SMUDGE: '1' };
+    }
+    return undefined;
+  }
+
   // ==========================================================================
   // LFS Operations
   // ==========================================================================
@@ -2506,6 +2530,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
 
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
+      env: this.lfsModeEnv(),
     });
   }
 
@@ -2974,6 +2999,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
 
     const result = await this.runner.run(this.context, args, {
       signal: opts?.signal,
+      env: this.lfsModeEnv(),
     });
 
     if (result.exitCode !== 0) {
@@ -3213,6 +3239,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
       onProgress: opts?.onProgress,
+      env: this.lfsModeEnv(),
     });
   }
 
@@ -3255,6 +3282,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
 
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
+      env: this.lfsModeEnv(),
     });
   }
 
@@ -3518,6 +3546,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
 
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
+      env: this.lfsModeEnv(),
     });
   }
 
@@ -4083,6 +4112,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
 
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
+      env: this.lfsModeEnv(),
     });
   }
 
@@ -4159,6 +4189,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
 
     await this.runner.runOrThrow(this.context, args, {
       signal: opts?.signal,
+      env: this.lfsModeEnv(),
     });
   }
 

--- a/src/impl/worktree-repo-impl.ts
+++ b/src/impl/worktree-repo-impl.ts
@@ -1069,7 +1069,7 @@ export class WorktreeRepoImpl implements WorktreeRepo {
    *
    * When the repository was opened (or reconfigured) with an object-form LFS
    * mode requesting `skipSmudge` and/or `skipDownload`, working-tree-populating
-   * operations (checkout, switch, reset, merge, pull, restore) run with
+   * operations (checkout, switch, reset, merge, pull, rebase, restore) run with
    * `GIT_LFS_SKIP_SMUDGE=1`. Git then leaves LFS pointer files in place instead
    * of downloading their contents during the implicit checkout.
    *

--- a/src/runner/cli-runner.ts
+++ b/src/runner/cli-runner.ts
@@ -149,10 +149,11 @@ export type CliRunnerOptions = {
 /**
  * Per-call options for {@link CliRunner.run} / {@link CliRunner.runOrThrow}.
  *
- * Extends the public {@link ExecOpts} with an internal `env` overlay so callers
- * (e.g. the repository implementations) can inject command-specific environment
- * variables — such as `GIT_LFS_SKIP_SMUDGE` for an LFS skip-smudge mode —
- * without widening the public API surface.
+ * Extends {@link ExecOpts} with an `env` overlay so callers (e.g. the repository
+ * implementations) can inject command-specific environment variables — such as
+ * `GIT_LFS_SKIP_SMUDGE` for an LFS skip-smudge mode. This keeps `env` out of the
+ * public `ExecOpts` / repository operation option types, scoping it to the
+ * runner's own `run` / `runOrThrow` entry points.
  */
 export type RunOptions = ExecOpts & {
   /**

--- a/src/runner/cli-runner.ts
+++ b/src/runner/cli-runner.ts
@@ -147,6 +147,23 @@ export type CliRunnerOptions = {
 };
 
 /**
+ * Per-call options for {@link CliRunner.run} / {@link CliRunner.runOrThrow}.
+ *
+ * Extends the public {@link ExecOpts} with an internal `env` overlay so callers
+ * (e.g. the repository implementations) can inject command-specific environment
+ * variables — such as `GIT_LFS_SKIP_SMUDGE` for an LFS skip-smudge mode —
+ * without widening the public API surface.
+ */
+export type RunOptions = ExecOpts & {
+  /**
+   * Extra environment variables merged on top of the resolved environment for
+   * this single command. Values here take precedence over the configured
+   * environment but do not persist across calls.
+   */
+  env?: Record<string, string>;
+};
+
+/**
  * CLI Runner for executing Git commands
  *
  * Handles:
@@ -318,11 +335,21 @@ export class CliRunner {
   /**
    * Run a Git command
    */
-  public async run(context: ExecutionContext, args: string[], opts?: ExecOpts): Promise<RawResult> {
+  public async run(
+    context: ExecutionContext,
+    args: string[],
+    opts?: RunOptions,
+  ): Promise<RawResult> {
     const argv = this.buildArgv(context, args);
-    const { signal, onProgress, onLfsProgress } = opts ?? {};
+    const { signal, onProgress, onLfsProgress, env: envOverride } = opts ?? {};
 
     const env = this.buildEnv();
+
+    // Apply per-call environment overrides (e.g. GIT_LFS_SKIP_SMUDGE) on top of
+    // the resolved environment.
+    if (envOverride) {
+      Object.assign(env, envOverride);
+    }
 
     // Enable LFS progress output to stderr when LFS progress callback is provided
     if (onLfsProgress) {
@@ -535,7 +562,7 @@ export class CliRunner {
   public async runOrThrow(
     context: ExecutionContext,
     args: string[],
-    opts?: ExecOpts,
+    opts?: RunOptions,
   ): Promise<RawResult> {
     const result = await this.run(context, args, opts);
     const error = this.mapError(result, context, this.buildArgv(context, args));


### PR DESCRIPTION
## Summary

Fixes **TG-2**: the object form of `LfsMode` (`{ skipSmudge?, skipDownload? }`) was stored on the repo but **never consulted** — every `_lfsMode` check was a `=== 'disabled'` string comparison. So `open({ lfs: { skipSmudge: true } })` was a silent no-op, and `checkout` / `pull` / etc. still ran the smudge filter and downloaded LFS content. In practice only `lfs: 'disabled'` did anything.

### What changed
- **`CliRunner.run` / `runOrThrow`** now accept an internal per-call `env` overlay (`RunOptions`), merged on top of the resolved environment. This keeps the overlay out of the public `ExecOpts` surface.
- **`WorktreeRepoImpl.lfsModeEnv()`** returns `{ GIT_LFS_SKIP_SMUDGE: '1' }` when the current mode is an object with `skipSmudge` or `skipDownload` truthy, else `undefined`. It reads `this._lfsMode` dynamically, so `setLfsMode()` is honored at runtime.
- The env is injected into the working-tree-populating operations: **`checkout`, `switch`, `reset`, `merge`, `pull`, `rebase`, `restore`**.

Git then leaves LFS pointer files in place instead of downloading their contents. Objects can be materialized later via the explicit `repo.lfs.pull()` / `repo.lfs.checkout()` helpers, which use dedicated git-lfs commands and are **not** affected by `GIT_LFS_SKIP_SMUDGE`.

### Notes / scope
- `skipDownload` is treated as implying skip-smudge (both map to `GIT_LFS_SKIP_SMUDGE=1`); there is no distinct git-lfs env for "fetch to cache but don't materialize" on these paths.
- The `'enabled'` / `'disabled'` string modes are unchanged. (`'disabled'` still only no-ops the `lfs.*` helpers; making it also skip smudge would be a separate behavior change.)
- Clone-with-checkout is out of scope here — `git.clone()` already exposes its own `skipSmudge` option.

## Test plan
- [x] New `src/impl/lfs-skip-smudge.test.ts` (13 tests): asserts `GIT_LFS_SKIP_SMUDGE=1` is set for each smudge op under `{ skipSmudge }` and `{ skipDownload }`; not set for `'enabled'` / `'disabled'` / `{}`; honored after `setLfsMode()`; and absent on non-smudge ops (`status`).
- [x] `pnpm typecheck`
- [x] `pnpm test:ci` (293 passed)
- [x] `pnpm check` (no new warnings)
- [x] Changeset added (`minor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SXWDUQPS6wQF8rRCRFmtr

---
_Generated by [Claude Code](https://claude.ai/code/session_011SXWDUQPS6wQF8rRCRFmtr)_